### PR TITLE
Return earlier when rcon connection invalid

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,10 +129,12 @@ func processCommand(c *gin.Context) {
 		if err != nil {
 			fmt.Println(err)
 			c.AbortWithError(http.StatusBadGateway, ErrInvalidDefaultConnection)
+			return
 		}
 	} else {
 		// no default connection and no connection info provided
 		c.AbortWithError(http.StatusBadRequest, ErrNoDefaultConnection)
+		return
 	}
 	defer conn.Close()
 


### PR DESCRIPTION
When a default connection server is being successfully initialized and the webserver isnt able to connect to it for a later request, we call `AbortWithError()` but that doesnt actually cause the function to return.

We then call methods on the RCON connection object which is nil in this case and causes errors:

```
2024/02/28 01:40:59 [Recovery] 2024/02/28 - 01:40:59 panic recovered:
runtime error: invalid memory address or nil pointer dereference
/usr/local/go/src/runtime/panic.go:261 (0x44bf37)
/usr/local/go/src/runtime/signal_unix.go:861 (0x44bf05)
/go/pkg/mod/github.com/gorcon/rcon@v1.3.5/rcon.go:168 (0x7d03ce)
/usr/local/go/src/runtime/panic.go:914 (0x4357fe)
/usr/local/go/src/runtime/panic.go:261 (0x44bf37)
/usr/local/go/src/runtime/signal_unix.go:861 (0x44bf05)
/go/pkg/mod/github.com/gorcon/rcon@v1.3.5/rcon.go:231 (0x7d07a0)
/go/pkg/mod/github.com/gorcon/rcon@v1.3.5/rcon.go:140 (0x7d02ac)
/app/main.go:139 (0x7d17e8)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x7c9d79)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/recovery.go:102 (0x7c9d67)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x7c8f1d)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/logger.go:240 (0x7c8ee0)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x7c7fda)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:620 (0x7c7c6d)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:576 (0x7c791c)
/usr/local/go/src/net/http/server.go:2938 (0x626a6d)
/usr/local/go/src/net/http/server.go:2009 (0x6237b3)
/usr/local/go/src/runtime/asm_amd64.s:1650 (0x467a60)
Error #01: error opening a connection to the specified default rcon server
invalid connection details to the rcon server were provided
```

returning earlier in these error cases resolves this.